### PR TITLE
Port to PHPOffice Spreadsheet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor/
 composer.phar
 composer.lock
 phpunit.xml
+/coverageReport/

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
   include:
     - php: 5.6
       env:
-        - COMPOSER_FLAGS="--prefer-lowest --prefer-stable"
+        - COMPOSER_FLAGS="--prefer-stable"
         - COVERAGE=true
         - PHPUNIT_FLAGS="--coverage-clover=coverage.clover"
 

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ clean:
 # End Cleaning Targets
 
 # Begin Test Targets
+test.all: phpcs phpunit
+test.strict: phpcs.warnings phpunit
+
 phpcs: phpcs.errors
 
 phpcbf: phpcbf.errors

--- a/Makefile
+++ b/Makefile
@@ -19,15 +19,19 @@ phpcbf: phpcbf.errors
 
 phpcs.warnings: composer
 	vendor/bin/phpcs -p --colors --standard=phpcs.xml src/
+	vendor/bin/phpcs -p --colors --standard=phpcs.xml tests/
 
 phpcbf.warnings: composer
 	vendor/bin/phpcbf -p --colors --standard=phpcs.xml src/
+	vendor/bin/phpcbf -p --colors --standard=phpcs.xml tests/
 
 phpcs.errors: composer
 	vendor/bin/phpcs -p --colors --warning-severity=0 --standard=phpcs.xml src/
+	vendor/bin/phpcs -p --colors --warning-severity=0 --standard=phpcs.xml tests/
 
 phpcbf.errors: composer
 	vendor/bin/phpcbf -p --colors --warning-severity=0 --standard=phpcs.xml src/
+	vendor/bin/phpcbf -p --colors --warning-severity=0 --standard=phpcs.xml tests/
 
 phpunit: composer
 	vendor/bin/phpunit

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ clean:
 # End Cleaning Targets
 
 # Begin Test Targets
+test: test.all
 test.all: phpcs phpunit phpstan
 test.strict: phpcs.warnings phpunit phpstan
 

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@ clean:
 # End Cleaning Targets
 
 # Begin Test Targets
-test.all: phpcs phpunit
-test.strict: phpcs.warnings phpunit
+test.all: phpcs phpunit phpstan
+test.strict: phpcs.warnings phpunit phpstan
 
 phpcs: phpcs.errors
 
@@ -35,6 +35,28 @@ phpcs.errors: composer
 phpcbf.errors: composer
 	vendor/bin/phpcbf -p --colors --warning-severity=0 --standard=phpcs.xml src/
 	vendor/bin/phpcbf -p --colors --warning-severity=0 --standard=phpcs.xml tests/
+
+# https://github.com/phpstan/phpstan#rule-levels
+phpstan: phpstan.default
+phpstan.default: phpstan.0
+phpstan.0: composer
+	vendor/bin/phpstan analyze -c phpstan.neon --level 0 -a vendor/autoload.php src
+phpstan.1: composer
+	vendor/bin/phpstan analyze -c phpstan.neon --level 1 -a vendor/autoload.php src
+phpstan.2: composer
+	vendor/bin/phpstan analyze -c phpstan.neon --level 2 -a vendor/autoload.php src
+phpstan.3: composer
+	vendor/bin/phpstan analyze -c phpstan.neon --level 3 -a vendor/autoload.php src
+phpstan.4: composer
+	vendor/bin/phpstan analyze -c phpstan.neon --level 4 -a vendor/autoload.php src
+phpstan.5: composer
+	vendor/bin/phpstan analyze -c phpstan.neon --level 5 -a vendor/autoload.php src
+phpstan.6: composer
+	vendor/bin/phpstan analyze -c phpstan.neon --level 6 -a vendor/autoload.php src
+phpstan.7: composer
+	vendor/bin/phpstan analyze -c phpstan.neon --level 7 -a vendor/autoload.php src
+phpstan.max: composer
+	vendor/bin/phpstan analyze -c phpstan.neon --level max -a vendor/autoload.php src
 
 phpunit: composer
 	vendor/bin/phpunit

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,9 @@ phpstan.max: composer
 
 phpunit: composer
 	vendor/bin/phpunit
+
+phpunit.coverage: composer
+	vendor/bin/phpunit --coverage-html coverageReport
 # End Test Targets
 
 # Begin Prepare Targets

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,39 @@
+# when you run 'make' alone, run the 'css' rule (at the
+# bottom of this makefile)
+all: phpcs phpunit
+
+# .PHONY is a special command, that allows you not to
+# require physical files as the target (allowing us to
+# use the 'all' rule as the default target).
+.PHONY: all
+
+# Begin Cleaning Targets
+clean:
+	git clean -Xdf
+# End Cleaning Targets
+
+# Begin Test Targets
+phpcs: phpcs.errors
+
+phpcbf: phpcbf.errors
+
+phpcs.warnings: composer
+	vendor/bin/phpcs -p --colors --standard=phpcs.xml src/
+
+phpcbf.warnings: composer
+	vendor/bin/phpcbf -p --colors --standard=phpcs.xml src/
+
+phpcs.errors: composer
+	vendor/bin/phpcs -p --colors --warning-severity=0 --standard=phpcs.xml src/
+
+phpcbf.errors: composer
+	vendor/bin/phpcbf -p --colors --warning-severity=0 --standard=phpcs.xml src/
+
+phpunit: composer
+	vendor/bin/phpunit
+# End Test Targets
+
+# Begin Prepare Targets
+composer:
+	composer install
+# End Prepare Targets

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "portphp/portphp": "^1.2.0",
-        "phpoffice/phpexcel": "~1.8"
+        "phpoffice/phpspreadsheet": "^1.3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -36,8 +36,7 @@
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4",
         "escapestudios/symfony2-coding-standard": "^3.4",
         "squizlabs/php_codesniffer": "^3.3",
-        "phpstan/phpstan": "^0.10",
-        "phpstan/phpstan-strict-rules": "^0.10"
+        "phpstan/phpstan": "^0.10"
     },
     "autoload-dev": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -35,8 +35,7 @@
         "phpunit/phpunit": "^4.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4",
         "escapestudios/symfony2-coding-standard": "^3.4",
-        "squizlabs/php_codesniffer": "^3.3",
-        "phpstan/phpstan": "^0.10"
+        "squizlabs/php_codesniffer": "^3.3"
     },
     "autoload-dev": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,10 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.0"
+        "phpunit/phpunit": "^4.0",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
+        "escapestudios/symfony2-coding-standard": "^3.4",
+        "squizlabs/php_codesniffer": "^3.3"
     },
     "autoload-dev": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -33,11 +33,11 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^4.0",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.4",
         "escapestudios/symfony2-coding-standard": "^3.4",
         "squizlabs/php_codesniffer": "^3.3",
-        "phpstan/phpstan": "^0.10.1",
-        "phpstan/phpstan-strict-rules": "^0.10.0"
+        "phpstan/phpstan": "^0.10",
+        "phpstan/phpstan-strict-rules": "^0.10"
     },
     "autoload-dev": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,9 @@
         "phpunit/phpunit": "^4.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
         "escapestudios/symfony2-coding-standard": "^3.4",
-        "squizlabs/php_codesniffer": "^3.3"
+        "squizlabs/php_codesniffer": "^3.3",
+        "phpstan/phpstan": "^0.10.1",
+        "phpstan/phpstan-strict-rules": "^0.10.0"
     },
     "autoload-dev": {
         "psr-4": {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<ruleset name="${PROJECT_NAME}">
+  <description>${PROJECT_DESCRIPTION}</description>
+
+  <rule ref="PSR1">
+    <exclude name="PSR1.Methods.CamelCapsMethodName.NotCamelCaps" />
+    <exclude name="Generic.Files.LineLength.TooLong" />
+  </rule>
+  <rule ref="PSR2" />
+
+  <rule ref="Generic.PHP.DeprecatedFunctions"/>
+  <rule ref="Generic.PHP.ForbiddenFunctions"/>
+  <rule ref="Generic.Functions.CallTimePassByReference"/>
+  <rule ref="Generic.Formatting.DisallowMultipleStatements"/>
+  <rule ref="Generic.CodeAnalysis.EmptyStatement" />
+  <rule ref="Generic.CodeAnalysis.ForLoopShouldBeWhileLoop"/>
+  <rule ref="Generic.CodeAnalysis.ForLoopWithTestFunctionCall"/>
+  <rule ref="Generic.CodeAnalysis.JumbledIncrementer"/>
+  <rule ref="Generic.CodeAnalysis.UnconditionalIfStatement"/>
+  <rule ref="Generic.CodeAnalysis.UnnecessaryFinalModifier"/>
+  <rule ref="Generic.CodeAnalysis.UselessOverridingMethod"/>
+  <rule ref="Generic.Classes.DuplicateClassName"/>
+  <rule ref="Generic.Strings.UnnecessaryStringConcat"/>
+
+  <rule ref="Symfony" />
+
+  <rule ref="Generic.Arrays.DisallowShortArraySyntax" />
+</ruleset>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,1 @@
 # vim: set ft=yaml:
-includes:
-    - vendor/phpstan/phpstan-strict-rules/rules.neon

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,3 @@
+# vim: set ft=yaml:
+includes:
+    - vendor/phpstan/phpstan-strict-rules/rules.neon

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,1 +1,0 @@
-# vim: set ft=yaml:

--- a/src/ExcelReader.php
+++ b/src/ExcelReader.php
@@ -94,7 +94,7 @@ class ExcelReader implements CountableReader, \SeekableIterator
         if (!empty($this->columnHeaders)) {
             // Count the number of elements in both: they must be equal.
             // If not, ignore the row
-            if (count($this->columnHeaders) == count($row)) {
+            if (count($this->columnHeaders) === count($row)) {
                 return array_combine(array_values($this->columnHeaders), $row);
             }
         } else {

--- a/src/ExcelReader.php
+++ b/src/ExcelReader.php
@@ -3,6 +3,8 @@
 namespace Port\Excel;
 
 use Port\Reader\CountableReader;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\IOFactory;
 
 /**
  * Reads Excel files with the help of PHPExcel
@@ -52,9 +54,9 @@ class ExcelReader implements CountableReader, \SeekableIterator
      */
     public function __construct(\SplFileObject $file, $headerRowNumber = null, $activeSheet = null, $readOnly = true, $maxRows = null)
     {
-        $reader = \PHPExcel_IOFactory::createReaderForFile($file->getPathName());
+        $reader = IOFactory::createReaderForFile($file->getPathName());
         $reader->setReadDataOnly($readOnly);
-        /** @var \PHPExcel $excel */
+        /** @var Spreadsheet $excel */
         $excel = $reader->load($file->getPathname());
 
         if (null !== $activeSheet) {

--- a/src/ExcelReader.php
+++ b/src/ExcelReader.php
@@ -45,6 +45,7 @@ class ExcelReader implements CountableReader, \SeekableIterator
      */
     protected $count;
 
+    // phpcs:disable Generic.Files.LineLength.MaxExceeded
     /**
      * @param \SplFileObject $file            Excel file
      * @param int            $headerRowNumber Optional number of header row
@@ -54,6 +55,7 @@ class ExcelReader implements CountableReader, \SeekableIterator
      */
     public function __construct(\SplFileObject $file, $headerRowNumber = null, $activeSheet = null, $readOnly = true, $maxRows = null)
     {
+        // phpcs:enable Generic.Files.LineLength.MaxExceeded
         $reader = IOFactory::createReaderForFile($file->getPathName());
         $reader->setReadDataOnly($readOnly);
         /** @var Spreadsheet $excel */

--- a/src/ExcelReader.php
+++ b/src/ExcelReader.php
@@ -101,7 +101,7 @@ class ExcelReader implements CountableReader, \SeekableIterator
     }
 
     /**
-     * {@inheritdoc}
+     * @return int
      */
     public function count()
     {
@@ -118,7 +118,7 @@ class ExcelReader implements CountableReader, \SeekableIterator
      *
      * If a header row has been set, an associative array will be returned
      *
-     * @return array
+     * @return array|null
      */
     public function current()
     {
@@ -165,7 +165,9 @@ class ExcelReader implements CountableReader, \SeekableIterator
     }
 
     /**
-     * {@inheritdoc}
+     * Return the key of the current element
+     *
+     * @return int
      */
     public function key()
     {
@@ -173,7 +175,9 @@ class ExcelReader implements CountableReader, \SeekableIterator
     }
 
     /**
-     * {@inheritdoc}
+     * Move forward to next element
+     *
+     * @return void Any returned value is ignored.
      */
     public function next()
     {
@@ -186,6 +190,8 @@ class ExcelReader implements CountableReader, \SeekableIterator
      * If a header row has been set, the pointer is set just below the header
      * row. That way, when you iterate over the rows, that header row is
      * skipped.
+     *
+     * @return void Any returned value is ignored.
      */
     public function rewind()
     {
@@ -197,7 +203,13 @@ class ExcelReader implements CountableReader, \SeekableIterator
     }
 
     /**
-     * {@inheritdoc}
+     * Seeks to a position
+     *
+     * @link http://php.net/manual/en/seekableiterator.seek.php
+     *
+     * @param int $pointer The position to seek to.
+     *
+     * @return void Any returned value is ignored.
      */
     public function seek($pointer)
     {
@@ -208,6 +220,8 @@ class ExcelReader implements CountableReader, \SeekableIterator
      * Set column headers
      *
      * @param array $columnHeaders
+     *
+     * @return void Any returned value is ignored.
      */
     public function setColumnHeaders(array $columnHeaders)
     {
@@ -218,6 +232,8 @@ class ExcelReader implements CountableReader, \SeekableIterator
      * Set header row number
      *
      * @param int $rowNumber Number of the row that contains column header names
+     *
+     * @return void Any returned value is ignored.
      */
     public function setHeaderRowNumber($rowNumber)
     {
@@ -226,7 +242,10 @@ class ExcelReader implements CountableReader, \SeekableIterator
     }
 
     /**
-     * {@inheritdoc}
+     * Checks if current position is valid
+     *
+     * @return bool The return value will be casted to boolean and then evaluated.
+     * Returns true on success or false on failure.
      */
     public function valid()
     {

--- a/src/ExcelReader.php
+++ b/src/ExcelReader.php
@@ -26,6 +26,7 @@ namespace Port\Excel;
 
 use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 use Port\Reader\CountableReader;
 
 /**
@@ -86,6 +87,8 @@ class ExcelReader implements CountableReader, \SeekableIterator
         if (null !== $activeSheet) {
             $excel->setActiveSheetIndex($activeSheet);
         }
+
+        /** @var Worksheet $sheet */
         $sheet = $excel->getActiveSheet();
 
         if ($maxRows && $maxRows < $sheet->getHighestDataRow()) {

--- a/src/ExcelReader.php
+++ b/src/ExcelReader.php
@@ -66,7 +66,7 @@ class ExcelReader implements CountableReader, \SeekableIterator
 
         if ($maxRows && $maxRows < $sheet->getHighestDataRow()) {
             $maxColumn = $sheet->getHighestDataColumn();
-            $this->worksheet = $sheet->rangeToArray('A1:' . $maxColumn . $maxRows);
+            $this->worksheet = $sheet->rangeToArray('A1:'.$maxColumn.$maxRows);
         } else {
             $this->worksheet = $excel->getActiveSheet()->toArray();
         }

--- a/src/ExcelReader.php
+++ b/src/ExcelReader.php
@@ -132,6 +132,8 @@ class ExcelReader implements CountableReader, \SeekableIterator
             if (count($this->columnHeaders) === count($row)) {
                 return array_combine(array_values($this->columnHeaders), $row);
             }
+
+            return null;
         } else {
             // Else just return the column values
             return $row;

--- a/src/ExcelReader.php
+++ b/src/ExcelReader.php
@@ -13,8 +13,8 @@ use PhpOffice\PhpSpreadsheet\IOFactory;
  *
  * @author David de Boer <david@ddeboer.nl>
  *
- * @link http://phpexcel.codeplex.com/
- * @link https://github.com/logiQ/PHPExcel
+ * @see http://phpexcel.codeplex.com/
+ * @see https://github.com/logiQ/PHPExcel
  */
 class ExcelReader implements CountableReader, \SeekableIterator
 {

--- a/src/ExcelReader.php
+++ b/src/ExcelReader.php
@@ -24,12 +24,12 @@ class ExcelReader implements CountableReader, \SeekableIterator
     protected $worksheet;
 
     /**
-     * @var integer
+     * @var int
      */
     protected $headerRowNumber;
 
     /**
-     * @var integer
+     * @var int
      */
     protected $pointer = 0;
 
@@ -41,16 +41,16 @@ class ExcelReader implements CountableReader, \SeekableIterator
     /**
      * Total number of rows
      *
-     * @var integer
+     * @var int
      */
     protected $count;
 
     /**
      * @param \SplFileObject $file            Excel file
-     * @param integer        $headerRowNumber Optional number of header row
-     * @param integer        $activeSheet     Index of active sheet to read from
-     * @param boolean        $readOnly        If set to false, the reader take care of the excel formatting (slow)
-     * @param integer        $maxRows         Maximum number of rows to read
+     * @param int            $headerRowNumber Optional number of header row
+     * @param int            $activeSheet     Index of active sheet to read from
+     * @param bool           $readOnly        If set to false, the reader take care of the excel formatting (slow)
+     * @param int            $maxRows         Maximum number of rows to read
      */
     public function __construct(\SplFileObject $file, $headerRowNumber = null, $activeSheet = null, $readOnly = true, $maxRows = null)
     {
@@ -140,7 +140,7 @@ class ExcelReader implements CountableReader, \SeekableIterator
     /**
      * Set header row number
      *
-     * @param integer $rowNumber Number of the row that contains column header names
+     * @param int $rowNumber Number of the row that contains column header names
      */
     public function setHeaderRowNumber($rowNumber)
     {
@@ -196,7 +196,7 @@ class ExcelReader implements CountableReader, \SeekableIterator
     /**
      * Get a row
      *
-     * @param integer $number
+     * @param int $number
      *
      * @return array
      */

--- a/src/ExcelReader.php
+++ b/src/ExcelReader.php
@@ -1,5 +1,27 @@
 <?php
+/*
+The MIT License (MIT)
 
+Copyright (c) 2015 PortPHP
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
 namespace Port\Excel;
 
 use Port\Reader\CountableReader;

--- a/src/ExcelReader.php
+++ b/src/ExcelReader.php
@@ -127,20 +127,14 @@ class ExcelReader implements CountableReader, \SeekableIterator
     {
         $row = $this->worksheet[$this->pointer];
 
-        // If the CSV has column headers, use them to construct an associative
+        // If the excel file has column headers, use them to construct an associative
         // array for the columns in this line
-        if (!empty($this->columnHeaders)) {
-            // Count the number of elements in both: they must be equal.
-            // If not, ignore the row
-            if (count($this->columnHeaders) === count($row)) {
-                return array_combine(array_values($this->columnHeaders), $row);
-            }
-
-            return null;
-        } else {
-            // Else just return the column values
-            return $row;
+        if (count($this->columnHeaders) === count($row)) {
+            return array_combine(array_values($this->columnHeaders), $row);
         }
+
+        // Else just return the column values
+        return $row;
     }
 
     /**

--- a/src/ExcelReaderFactory.php
+++ b/src/ExcelReaderFactory.php
@@ -1,5 +1,27 @@
 <?php
+/*
+The MIT License (MIT)
 
+Copyright (c) 2015 PortPHP
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
 namespace Port\Excel;
 
 use Port\Reader\ReaderFactory;

--- a/src/ExcelReaderFactory.php
+++ b/src/ExcelReaderFactory.php
@@ -12,18 +12,18 @@ use Port\Reader\ReaderFactory;
 class ExcelReaderFactory implements ReaderFactory
 {
     /**
-     * @var integer
+     * @var int
      */
     protected $headerRowNumber;
 
     /**
-     * @var integer
+     * @var int
      */
     protected $activeSheet;
 
     /**
-     * @param integer $headerRowNumber
-     * @param integer $activeSheet
+     * @param int $headerRowNumber
+     * @param int $activeSheet
      */
     public function __construct($headerRowNumber = null, $activeSheet = null)
     {

--- a/src/ExcelReaderFactory.php
+++ b/src/ExcelReaderFactory.php
@@ -21,7 +21,7 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-*/
+ */
 namespace Port\Excel;
 
 use Port\Reader\ReaderFactory;
@@ -36,12 +36,12 @@ class ExcelReaderFactory implements ReaderFactory
     /**
      * @var int
      */
-    protected $headerRowNumber;
+    protected $activeSheet;
 
     /**
      * @var int
      */
-    protected $activeSheet;
+    protected $headerRowNumber;
 
     /**
      * @param int $headerRowNumber
@@ -50,7 +50,7 @@ class ExcelReaderFactory implements ReaderFactory
     public function __construct($headerRowNumber = null, $activeSheet = null)
     {
         $this->headerRowNumber = $headerRowNumber;
-        $this->activeSheet = $activeSheet;
+        $this->activeSheet     = $activeSheet;
     }
 
     /**

--- a/src/ExcelWriter.php
+++ b/src/ExcelWriter.php
@@ -1,5 +1,27 @@
 <?php
+/*
+The MIT License (MIT)
 
+Copyright (c) 2015 PortPHP
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
 namespace Port\Excel;
 
 use Port\Writer;

--- a/src/ExcelWriter.php
+++ b/src/ExcelWriter.php
@@ -88,7 +88,7 @@ class ExcelWriter implements Writer
             $headers = array_keys($item);
 
             for ($i = 0; $i < $count; $i++) {
-                $this->excel->getActiveSheet()->setCellValueByColumnAndRow($i, $this->row, $headers[$i]);
+                $this->excel->getActiveSheet()->setCellValueByColumnAndRow($i+1, $this->row, $headers[$i]);
             }
             $this->row++;
         }
@@ -96,7 +96,7 @@ class ExcelWriter implements Writer
         $values = array_values($item);
 
         for ($i = 0; $i < $count; $i++) {
-            $this->excel->getActiveSheet()->setCellValueByColumnAndRow($i, $this->row, $values[$i]);
+            $this->excel->getActiveSheet()->setCellValueByColumnAndRow($i+1, $this->row, $values[$i]);
         }
 
         $this->row++;

--- a/src/ExcelWriter.php
+++ b/src/ExcelWriter.php
@@ -29,7 +29,7 @@ class ExcelWriter implements Writer
     protected $type;
 
     /**
-     * @var boolean
+     * @var bool
      */
     protected $prependHeaderRow;
 
@@ -39,7 +39,7 @@ class ExcelWriter implements Writer
     protected $excel;
 
     /**
-     * @var integer
+     * @var int
      */
     protected $row = 1;
 
@@ -47,7 +47,7 @@ class ExcelWriter implements Writer
      * @param \SplFileObject $file  File
      * @param string         $sheet Sheet title (optional)
      * @param string         $type  Excel file type (defaults to Xlsx)
-     * @param boolean        $prependHeaderRow
+     * @param bool           $prependHeaderRow
      */
     public function __construct(\SplFileObject $file, $sheet = null, $type = 'Xlsx', $prependHeaderRow = false)
     {

--- a/src/ExcelWriter.php
+++ b/src/ExcelWriter.php
@@ -21,12 +21,12 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-*/
+ */
 namespace Port\Excel;
 
-use Port\Writer;
-use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\IOFactory;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use Port\Writer;
 
 /**
  * Writes to an Excel file
@@ -36,9 +36,24 @@ use PhpOffice\PhpSpreadsheet\IOFactory;
 class ExcelWriter implements Writer
 {
     /**
+     * @var Spreadsheet
+     */
+    protected $excel;
+
+    /**
      * @var string
      */
     protected $filename;
+
+    /**
+     * @var bool
+     */
+    protected $prependHeaderRow;
+
+    /**
+     * @var int
+     */
+    protected $row = 1;
 
     /**
      * @var null|string
@@ -51,21 +66,6 @@ class ExcelWriter implements Writer
     protected $type;
 
     /**
-     * @var bool
-     */
-    protected $prependHeaderRow;
-
-    /**
-     * @var Spreadsheet
-     */
-    protected $excel;
-
-    /**
-     * @var int
-     */
-    protected $row = 1;
-
-    /**
      * @param \SplFileObject $file             File
      * @param string         $sheet            Sheet title (optional)
      * @param string         $type             Excel file type (defaults to Xlsx)
@@ -73,10 +73,19 @@ class ExcelWriter implements Writer
      */
     public function __construct(\SplFileObject $file, $sheet = null, $type = 'Xlsx', $prependHeaderRow = false)
     {
-        $this->filename = $file->getPathname();
-        $this->sheet = $sheet;
-        $this->type = $type;
+        $this->filename         = $file->getPathname();
+        $this->sheet            = $sheet;
+        $this->type             = $type;
         $this->prependHeaderRow = $prependHeaderRow;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function finish()
+    {
+        $writer = IOFactory::createWriter($this->excel, $this->type);
+        $writer->save($this->filename);
     }
 
     /**
@@ -110,7 +119,7 @@ class ExcelWriter implements Writer
             $headers = array_keys($item);
 
             for ($i = 0; $i < $count; $i++) {
-                $this->excel->getActiveSheet()->setCellValueByColumnAndRow($i+1, $this->row, $headers[$i]);
+                $this->excel->getActiveSheet()->setCellValueByColumnAndRow($i + 1, $this->row, $headers[$i]);
             }
             $this->row++;
         }
@@ -118,18 +127,9 @@ class ExcelWriter implements Writer
         $values = array_values($item);
 
         for ($i = 0; $i < $count; $i++) {
-            $this->excel->getActiveSheet()->setCellValueByColumnAndRow($i+1, $this->row, $values[$i]);
+            $this->excel->getActiveSheet()->setCellValueByColumnAndRow($i + 1, $this->row, $values[$i]);
         }
 
         $this->row++;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function finish()
-    {
-        $writer = IOFactory::createWriter($this->excel, $this->type);
-        $writer->save($this->filename);
     }
 }

--- a/src/ExcelWriter.php
+++ b/src/ExcelWriter.php
@@ -44,9 +44,9 @@ class ExcelWriter implements Writer
     protected $row = 1;
 
     /**
-     * @param \SplFileObject $file  File
-     * @param string         $sheet Sheet title (optional)
-     * @param string         $type  Excel file type (defaults to Xlsx)
+     * @param \SplFileObject $file             File
+     * @param string         $sheet            Sheet title (optional)
+     * @param string         $type             Excel file type (defaults to Xlsx)
      * @param bool           $prependHeaderRow
      */
     public function __construct(\SplFileObject $file, $sheet = null, $type = 'Xlsx', $prependHeaderRow = false)

--- a/src/ExcelWriter.php
+++ b/src/ExcelWriter.php
@@ -84,7 +84,7 @@ class ExcelWriter implements Writer
     {
         $count = count($item);
 
-        if ($this->prependHeaderRow && 1 == $this->row) {
+        if ($this->prependHeaderRow && 1 === $this->row) {
             $headers = array_keys($item);
 
             for ($i = 0; $i < $count; $i++) {

--- a/src/ExcelWriter.php
+++ b/src/ExcelWriter.php
@@ -3,8 +3,8 @@
 namespace Port\Excel;
 
 use Port\Writer;
-use PHPExcel;
-use PHPExcel_IOFactory;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\IOFactory;
 
 /**
  * Writes to an Excel file
@@ -34,7 +34,7 @@ class ExcelWriter implements Writer
     protected $prependHeaderRow;
 
     /**
-     * @var PHPExcel
+     * @var Spreadsheet
      */
     protected $excel;
 
@@ -46,10 +46,10 @@ class ExcelWriter implements Writer
     /**
      * @param \SplFileObject $file  File
      * @param string         $sheet Sheet title (optional)
-     * @param string         $type  Excel file type (defaults to Excel2007)
+     * @param string         $type  Excel file type (defaults to Xlsx)
      * @param boolean        $prependHeaderRow
      */
-    public function __construct(\SplFileObject $file, $sheet = null, $type = 'Excel2007', $prependHeaderRow = false)
+    public function __construct(\SplFileObject $file, $sheet = null, $type = 'Xlsx', $prependHeaderRow = false)
     {
         $this->filename = $file->getPathname();
         $this->sheet = $sheet;
@@ -62,11 +62,11 @@ class ExcelWriter implements Writer
      */
     public function prepare()
     {
-        $reader = PHPExcel_IOFactory::createReader($this->type);
+        $reader = IOFactory::createReader($this->type);
         if ($reader->canRead($this->filename)) {
             $this->excel = $reader->load($this->filename);
         } else {
-            $this->excel = new PHPExcel();
+            $this->excel = new Spreadsheet();
         }
 
         if (null !== $this->sheet) {
@@ -107,7 +107,7 @@ class ExcelWriter implements Writer
      */
     public function finish()
     {
-        $writer = \PHPExcel_IOFactory::createWriter($this->excel, $this->type);
+        $writer = IOFactory::createWriter($this->excel, $this->type);
         $writer->save($this->filename);
     }
 }

--- a/src/ExcelWriter.php
+++ b/src/ExcelWriter.php
@@ -80,7 +80,9 @@ class ExcelWriter implements Writer
     }
 
     /**
-     * {@inheritdoc}
+     * Wrap up the writer after all items have been written
+     *
+     * @return void Any returned value is ignored.
      */
     public function finish()
     {
@@ -89,7 +91,9 @@ class ExcelWriter implements Writer
     }
 
     /**
-     * {@inheritdoc}
+     * Prepare the writer before writing the items
+     *
+     * @return void Any returned value is ignored.
      */
     public function prepare()
     {
@@ -109,7 +113,11 @@ class ExcelWriter implements Writer
     }
 
     /**
-     * {@inheritdoc}
+     * Write one data item
+     *
+     * @param array $item The data item with converted values
+     *
+     * @return void Any returned value is ignored.
      */
     public function writeItem(array $item)
     {

--- a/tests/ExcelReaderFactoryTest.php
+++ b/tests/ExcelReaderFactoryTest.php
@@ -1,5 +1,27 @@
 <?php
+/*
+The MIT License (MIT)
 
+Copyright (c) 2015 PortPHP
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
 namespace Port\Excel\Tests;
 
 use Port\Excel\ExcelReaderFactory;

--- a/tests/ExcelReaderFactoryTest.php
+++ b/tests/ExcelReaderFactoryTest.php
@@ -13,6 +13,9 @@ class ExcelReaderFactoryTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    /**
+     *
+     */
     public function testGetReader()
     {
         $factory = new ExcelReaderFactory();

--- a/tests/ExcelReaderFactoryTest.php
+++ b/tests/ExcelReaderFactoryTest.php
@@ -21,7 +21,7 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-*/
+ */
 namespace Port\Excel\Tests;
 
 use Port\Excel\ExcelReaderFactory;
@@ -47,12 +47,12 @@ class ExcelReaderFactoryTest extends \PHPUnit_Framework_TestCase
     public function testGetReader()
     {
         $factory = new ExcelReaderFactory();
-        $reader = $factory->getReader(new \SplFileObject(__DIR__.'/fixtures/data_column_headers.xlsx'));
+        $reader  = $factory->getReader(new \SplFileObject(__DIR__.'/fixtures/data_column_headers.xlsx'));
         $this->assertInstanceOf('\Port\Excel\ExcelReader', $reader);
         $this->assertCount(4, $reader);
 
         $factory = new ExcelReaderFactory(0);
-        $reader = $factory->getReader(new \SplFileObject(__DIR__.'/fixtures/data_column_headers.xlsx'));
+        $reader  = $factory->getReader(new \SplFileObject(__DIR__.'/fixtures/data_column_headers.xlsx'));
         $this->assertCount(3, $reader);
     }
 }

--- a/tests/ExcelReaderFactoryTest.php
+++ b/tests/ExcelReaderFactoryTest.php
@@ -4,8 +4,14 @@ namespace Port\Excel\Tests;
 
 use Port\Excel\ExcelReaderFactory;
 
+/**
+ * {@inheritDoc}
+ */
 class ExcelReaderFactoryTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * {@inheritDoc}
+     */
     public function setUp()
     {
         if (!extension_loaded('zip')) {

--- a/tests/ExcelReaderTest.php
+++ b/tests/ExcelReaderTest.php
@@ -13,6 +13,9 @@ class ExcelReaderTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    /**
+     *
+     */
     public function testCountWithoutHeaders()
     {
         $file = new \SplFileObject(__DIR__.'/fixtures/data_no_column_headers.xls');
@@ -20,6 +23,9 @@ class ExcelReaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(3, $reader->count());
     }
 
+    /**
+     *
+     */
     public function testCountWithHeaders()
     {
         $file = new \SplFileObject(__DIR__.'/fixtures/data_column_headers.xlsx');
@@ -27,6 +33,9 @@ class ExcelReaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(3, $reader->count());
     }
 
+    /**
+     *
+     */
     public function testIterate()
     {
         $file = new \SplFileObject(__DIR__.'/fixtures/data_column_headers.xlsx');
@@ -37,6 +46,9 @@ class ExcelReaderTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    /**
+     *
+     */
     public function testMultiSheet()
     {
         $file = new \SplFileObject(__DIR__.'/fixtures/data_multi_sheet.xls');
@@ -47,6 +59,9 @@ class ExcelReaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(2, $sheet2reader->count());
     }
 
+    /**
+     *
+     */
     public function testMaxRowNumb()
     {
         $file = new \SplFileObject(__DIR__.'/fixtures/data_no_column_headers.xls');

--- a/tests/ExcelReaderTest.php
+++ b/tests/ExcelReaderTest.php
@@ -1,5 +1,27 @@
 <?php
+/*
+The MIT License (MIT)
 
+Copyright (c) 2015 PortPHP
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
 namespace Port\Excel\Tests;
 
 use Port\Excel\ExcelReader;

--- a/tests/ExcelReaderTest.php
+++ b/tests/ExcelReaderTest.php
@@ -21,7 +21,7 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-*/
+ */
 namespace Port\Excel\Tests;
 
 use Port\Excel\ExcelReader;
@@ -44,20 +44,20 @@ class ExcelReaderTest extends \PHPUnit_Framework_TestCase
     /**
      *
      */
-    public function testCountWithoutHeaders()
+    public function testCountWithHeaders()
     {
-        $file = new \SplFileObject(__DIR__.'/fixtures/data_no_column_headers.xls');
-        $reader = new ExcelReader($file);
+        $file   = new \SplFileObject(__DIR__.'/fixtures/data_column_headers.xlsx');
+        $reader = new ExcelReader($file, 0);
         $this->assertEquals(3, $reader->count());
     }
 
     /**
      *
      */
-    public function testCountWithHeaders()
+    public function testCountWithoutHeaders()
     {
-        $file = new \SplFileObject(__DIR__.'/fixtures/data_column_headers.xlsx');
-        $reader = new ExcelReader($file, 0);
+        $file   = new \SplFileObject(__DIR__.'/fixtures/data_no_column_headers.xls');
+        $reader = new ExcelReader($file);
         $this->assertEquals(3, $reader->count());
     }
 
@@ -120,22 +120,9 @@ class ExcelReaderTest extends \PHPUnit_Framework_TestCase
     /**
      *
      */
-    public function testMultiSheet()
-    {
-        $file = new \SplFileObject(__DIR__.'/fixtures/data_multi_sheet.xls');
-        $sheet1reader = new ExcelReader($file, null, 0);
-        $this->assertEquals(3, $sheet1reader->count());
-
-        $sheet2reader = new ExcelReader($file, null, 1);
-        $this->assertEquals(2, $sheet2reader->count());
-    }
-
-    /**
-     *
-     */
     public function testMaxRowNumb()
     {
-        $file = new \SplFileObject(__DIR__.'/fixtures/data_no_column_headers.xls');
+        $file   = new \SplFileObject(__DIR__.'/fixtures/data_no_column_headers.xls');
         $reader = new ExcelReader($file, null, null, null, 1000);
         $this->assertEquals(3, $reader->count());
 
@@ -143,8 +130,21 @@ class ExcelReaderTest extends \PHPUnit_Framework_TestCase
         //high last row number
         $file = new \SplFileObject(__DIR__.'/fixtures/data_extreme_last_row.xlsx');
 
-        $max = 5;
+        $max    = 5;
         $reader = new ExcelReader($file, null, null, null, $max);
         $this->assertEquals($max, $reader->count());
+    }
+
+    /**
+     *
+     */
+    public function testMultiSheet()
+    {
+        $file         = new \SplFileObject(__DIR__.'/fixtures/data_multi_sheet.xls');
+        $sheet1reader = new ExcelReader($file, null, 0);
+        $this->assertEquals(3, $sheet1reader->count());
+
+        $sheet2reader = new ExcelReader($file, null, 1);
+        $this->assertEquals(2, $sheet2reader->count());
     }
 }

--- a/tests/ExcelReaderTest.php
+++ b/tests/ExcelReaderTest.php
@@ -4,8 +4,14 @@ namespace Port\Excel\Tests;
 
 use Port\Excel\ExcelReader;
 
+/**
+ * {@inheritDoc}
+ */
 class ExcelReaderTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * {@inheritDoc}
+     */
     public function setUp()
     {
         if (!extension_loaded('zip')) {

--- a/tests/ExcelReaderTest.php
+++ b/tests/ExcelReaderTest.php
@@ -42,14 +42,57 @@ class ExcelReaderTest extends \PHPUnit_Framework_TestCase
     /**
      *
      */
-    public function testIterate()
+    public function testIterateWithHeaders()
     {
-        $file = new \SplFileObject(__DIR__.'/fixtures/data_column_headers.xlsx');
+        $file   = new \SplFileObject(__DIR__.'/fixtures/data_column_headers.xlsx');
         $reader = new ExcelReader($file, 0);
+
+        $actualData   = array();
+        $expectedData = array(
+            array(
+                'id'          => 50.0,
+                'number'      => 123.0,
+                'description' => 'Description',
+            ),
+            array(
+                'id'          => 6.0,
+                'number'      => 456.0,
+                'description' => 'Another description',
+            ),
+            array(
+                'id'          => 7.0,
+                'number'      => 7890.0,
+                'description' => 'Some more info',
+            ),
+        );
+
         foreach ($reader as $row) {
-            $this->assertInternalType('array', $row);
-            $this->assertEquals(array('id', 'number', 'description'), array_keys($row));
+            $actualData[] = $row;
         }
+
+        $this->assertEquals($expectedData, $actualData);
+    }
+
+    /**
+     *
+     */
+    public function testIterateWithoutHeaders()
+    {
+        $file   = new \SplFileObject(__DIR__.'/fixtures/data_no_column_headers.xls');
+        $reader = new ExcelReader($file);
+
+        $actualData   = array();
+        $expectedData = array(
+            array(50.0, 123.0, "Description"),
+            array(6.0, 456.0, 'Another description'),
+            array(7.0, 7890.0, 'Some more info'),
+        );
+
+        foreach ($reader as $row) {
+            $actualData[] = $row;
+        }
+
+        $this->assertEquals($expectedData, $actualData);
     }
 
     /**

--- a/tests/ExcelReaderTest.php
+++ b/tests/ExcelReaderTest.php
@@ -167,6 +167,7 @@ class ExcelReaderTest extends \PHPUnit_Framework_TestCase
             ),
             $row
         );
+        $this->assertEquals(0, $reader->key());
 
         $row = $reader->getRow(3);
         $this->assertEquals(
@@ -177,6 +178,7 @@ class ExcelReaderTest extends \PHPUnit_Framework_TestCase
             ),
             $row
         );
+        $this->assertEquals(3, $reader->key());
 
         $row = $reader->getRow(1);
         $this->assertEquals(
@@ -187,6 +189,7 @@ class ExcelReaderTest extends \PHPUnit_Framework_TestCase
             ),
             $row
         );
+        $this->assertEquals(1, $reader->key());
 
         $row = $reader->getRow(2);
         $this->assertEquals(
@@ -197,6 +200,7 @@ class ExcelReaderTest extends \PHPUnit_Framework_TestCase
             ),
             $row
         );
+        $this->assertEquals(2, $reader->key());
     }
 
     /**

--- a/tests/ExcelReaderTest.php
+++ b/tests/ExcelReaderTest.php
@@ -147,4 +147,94 @@ class ExcelReaderTest extends \PHPUnit_Framework_TestCase
         $sheet2reader = new ExcelReader($file, null, 1);
         $this->assertEquals(2, $sheet2reader->count());
     }
+
+    /**
+     *
+     */
+    public function testSeekWithHeaders()
+    {
+        $file   = new \SplFileObject(__DIR__.'/fixtures/data_column_headers.xlsx');
+        $reader = new ExcelReader($file, 0);
+
+        // TODO: Check if row 0 should return the header row if headers are enabled.
+        // Row 0 returns the header row as data and indexes.
+        $row = $reader->getRow(0);
+        $this->assertEquals(
+            array(
+                'id'          => 'id',
+                'number'      => 'number',
+                'description' => 'description',
+            ),
+            $row
+        );
+
+        $row = $reader->getRow(3);
+        $this->assertEquals(
+            array(
+                'id'          => 7.0,
+                'number'      => 7890.0,
+                'description' => 'Some more info',
+            ),
+            $row
+        );
+
+        $row = $reader->getRow(1);
+        $this->assertEquals(
+            array(
+                'id'          => 50.0,
+                'number'      => 123.0,
+                'description' => 'Description',
+            ),
+            $row
+        );
+
+        $row = $reader->getRow(2);
+        $this->assertEquals(
+            array(
+                'id'          => 6.0,
+                'number'      => 456.0,
+                'description' => 'Another description',
+            ),
+            $row
+        );
+    }
+
+    /**
+     *
+     */
+    public function testSeekWithoutHeaders()
+    {
+        $file   = new \SplFileObject(__DIR__.'/fixtures/data_no_column_headers.xls');
+        $reader = new ExcelReader($file);
+
+        $row = $reader->getRow(2);
+        $this->assertEquals(
+            array(
+                7.0,
+                7890.0,
+                'Some more info',
+            ),
+            $row
+        );
+
+        $row = $reader->getRow(0);
+        $this->assertEquals(
+            array(
+                50.0,
+                123.0,
+                'Description',
+            ),
+            $row
+        );
+
+        $row = $reader->getRow(1);
+        $this->assertEquals(
+            array(
+                6.0,
+                456.0,
+                'Another description',
+            ),
+            $row
+        );
+    }
 }

--- a/tests/ExcelReaderTest.php
+++ b/tests/ExcelReaderTest.php
@@ -64,6 +64,130 @@ class ExcelReaderTest extends \PHPUnit_Framework_TestCase
     /**
      *
      */
+    public function testCustomColumnHeadersWithHeaders()
+    {
+        $file   = new \SplFileObject(__DIR__.'/fixtures/data_column_headers.xlsx');
+        $reader = new ExcelReader($file, 0);
+
+        $this->assertEquals(
+            array(
+                'id',
+                'number',
+                'description',
+            ),
+            $reader->getColumnHeaders()
+        );
+
+        $reader->setColumnHeaders(
+            array(
+                'id2',
+                'number2',
+                'description2',
+            )
+        );
+
+        $this->assertEquals(
+            array(
+                'id2',
+                'number2',
+                'description2',
+            ),
+            $reader->getColumnHeaders()
+        );
+
+        // TODO: Check if row 0 should return the header row if headers are enabled.
+        // Row 0 returns the header row as data and indexes.
+        $row = $reader->getRow(0);
+        $this->assertEquals(
+            array(
+                'id2'          => 'id',
+                'number2'      => 'number',
+                'description2' => 'description',
+            ),
+            $row
+        );
+
+        $row = $reader->getRow(3);
+        $this->assertEquals(
+            array(
+                'id2'          => 7.0,
+                'number2'      => 7890.0,
+                'description2' => 'Some more info',
+            ),
+            $row
+        );
+
+        $row = $reader->getRow(1);
+        $this->assertEquals(
+            array(
+                'id2'          => 50.0,
+                'number2'      => 123.0,
+                'description2' => 'Description',
+            ),
+            $row
+        );
+
+        $row = $reader->getRow(2);
+        $this->assertEquals(
+            array(
+                'id2'          => 6.0,
+                'number2'      => 456.0,
+                'description2' => 'Another description',
+            ),
+            $row
+        );
+    }
+
+    /**
+     *
+     */
+    public function testCustomColumnHeadersWithoutHeaders()
+    {
+        $file   = new \SplFileObject(__DIR__.'/fixtures/data_no_column_headers.xls');
+        $reader = new ExcelReader($file);
+
+        $reader->setColumnHeaders(
+            array(
+                'id',
+                'number',
+                'description',
+            )
+        );
+
+        $row = $reader->getRow(2);
+        $this->assertEquals(
+            array(
+                'id'          => 7.0,
+                'number'      => 7890.0,
+                'description' => 'Some more info',
+            ),
+            $row
+        );
+
+        $row = $reader->getRow(0);
+        $this->assertEquals(
+            array(
+                'id'          => 50.0,
+                'number'      => 123.0,
+                'description' => 'Description',
+            ),
+            $row
+        );
+
+        $row = $reader->getRow(1);
+        $this->assertEquals(
+            array(
+                'id'          => 6.0,
+                'number'      => 456.0,
+                'description' => 'Another description',
+            ),
+            $row
+        );
+    }
+
+    /**
+     *
+     */
     public function testIterateWithHeaders()
     {
         $file   = new \SplFileObject(__DIR__.'/fixtures/data_column_headers.xlsx');

--- a/tests/ExcelWriterTest.php
+++ b/tests/ExcelWriterTest.php
@@ -14,6 +14,9 @@ class ExcelWriterTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    /**
+     *
+     */
     public function testWriteItemAppendWithSheetTitle()
     {
         $file = tempnam(sys_get_temp_dir(), null);
@@ -58,6 +61,9 @@ class ExcelWriterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(2, $excel->getSheetByName('Sheet 2')->getHighestRow());
     }
 
+    /**
+     *
+     */
     public function testWriteItemWithoutSheetTitle()
     {
         $outputFile = new \SplFileObject(tempnam(sys_get_temp_dir(), null));

--- a/tests/ExcelWriterTest.php
+++ b/tests/ExcelWriterTest.php
@@ -5,8 +5,14 @@ namespace Port\Excel\Tests;
 use Port\Excel\ExcelWriter;
 use PhpOffice\PhpSpreadsheet\IOFactory;
 
+/**
+ * {@inheritDoc}
+ */
 class ExcelWriterTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * {@inheritDoc}
+     */
     public function setUp()
     {
         if (!extension_loaded('zip')) {

--- a/tests/ExcelWriterTest.php
+++ b/tests/ExcelWriterTest.php
@@ -95,9 +95,9 @@ class ExcelWriterTest extends \PHPUnit_Framework_TestCase
         $writer = new ExcelWriter(new \SplFileObject($file, 'w'), null, 'Xlsx');
         $writer->prepare();
         $writer->writeItem(array(
-            'col 1 name'=>'col 1 value',
-            'col 2 name'=>'col 2 value',
-            'col 3 name'=>'col 3 value',
+            'col 1 name' => 'col 1 value',
+            'col 2 name' => 'col 2 value',
+            'col 3 name' => 'col 3 value',
         ));
         $writer->finish();
 
@@ -123,9 +123,9 @@ class ExcelWriterTest extends \PHPUnit_Framework_TestCase
         $writer = new ExcelWriter(new \SplFileObject($file, 'w'), null, 'Xlsx', true);
         $writer->prepare();
         $writer->writeItem(array(
-            'col 1 name'=>'col 1 value',
-            'col 2 name'=>'col 2 value',
-            'col 3 name'=>'col 3 value',
+            'col 1 name' => 'col 1 value',
+            'col 2 name' => 'col 2 value',
+            'col 3 name' => 'col 3 value',
         ));
         $writer->finish();
 

--- a/tests/ExcelWriterTest.php
+++ b/tests/ExcelWriterTest.php
@@ -21,11 +21,11 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-*/
+ */
 namespace Port\Excel\Tests;
 
-use Port\Excel\ExcelWriter;
 use PhpOffice\PhpSpreadsheet\IOFactory;
+use Port\Excel\ExcelWriter;
 
 /**
  * {@inheritDoc}
@@ -40,6 +40,62 @@ class ExcelWriterTest extends \PHPUnit_Framework_TestCase
         if (!extension_loaded('zip')) {
             $this->markTestSkipped();
         }
+    }
+
+    /**
+     * Test that column names not prepended to first row if ExcelWriter's 4-th
+     * parameter not given
+     *
+     * @author  Igor Mukhin <igor.mukhin@gmail.com>
+     */
+    public function testHeaderNotPrependedByDefault()
+    {
+        $file = tempnam(sys_get_temp_dir(), null);
+
+        $writer = new ExcelWriter(new \SplFileObject($file, 'w'), null, 'Xlsx');
+        $writer->prepare();
+        $writer->writeItem(array(
+            'col 1 name' => 'col 1 value',
+            'col 2 name' => 'col 2 value',
+            'col 3 name' => 'col 3 value',
+        ));
+        $writer->finish();
+
+        $excel = IOFactory::load($file);
+        $sheet = $excel->getActiveSheet()->toArray();
+
+        // Values should be at first line
+        $this->assertEquals(array('col 1 value', 'col 2 value', 'col 3 value'), $sheet[0]);
+    }
+
+    /**
+     * Test that column names prepended at first row
+     * and values have been written at second line
+     * if ExcelWriter's 4-th parameter set to true
+     *
+     * @author  Igor Mukhin <igor.mukhin@gmail.com>
+     */
+    public function testHeaderPrependedWhenOptionSetToTrue()
+    {
+        $file = tempnam(sys_get_temp_dir(), null);
+
+        $writer = new ExcelWriter(new \SplFileObject($file, 'w'), null, 'Xlsx', true);
+        $writer->prepare();
+        $writer->writeItem(array(
+            'col 1 name' => 'col 1 value',
+            'col 2 name' => 'col 2 value',
+            'col 3 name' => 'col 3 value',
+        ));
+        $writer->finish();
+
+        $excel = IOFactory::load($file);
+        $sheet = $excel->getActiveSheet()->toArray();
+
+        // Check column names at first line
+        $this->assertEquals(array('col 1 name', 'col 2 name', 'col 3 name'), $sheet[0]);
+
+        // Check values at second line
+        $this->assertEquals(array('col 1 value', 'col 2 value', 'col 3 value'), $sheet[1]);
     }
 
     /**
@@ -95,69 +151,12 @@ class ExcelWriterTest extends \PHPUnit_Framework_TestCase
     public function testWriteItemWithoutSheetTitle()
     {
         $outputFile = new \SplFileObject(tempnam(sys_get_temp_dir(), null));
-        $writer = new ExcelWriter($outputFile);
+        $writer     = new ExcelWriter($outputFile);
 
         $writer->prepare();
 
         $writer->writeItem(array('first', 'last'));
 
         $writer->finish();
-    }
-
-    /**
-     * Test that column names not prepended to first row if ExcelWriter's 4-th
-     * parameter not given
-     *
-     * @author  Igor Mukhin <igor.mukhin@gmail.com>
-     */
-    public function testHeaderNotPrependedByDefault()
-    {
-        $file = tempnam(sys_get_temp_dir(), null);
-
-        $writer = new ExcelWriter(new \SplFileObject($file, 'w'), null, 'Xlsx');
-        $writer->prepare();
-        $writer->writeItem(array(
-            'col 1 name' => 'col 1 value',
-            'col 2 name' => 'col 2 value',
-            'col 3 name' => 'col 3 value',
-        ));
-        $writer->finish();
-
-        $excel = IOFactory::load($file);
-        $sheet = $excel->getActiveSheet()->toArray();
-
-        // Values should be at first line
-        $this->assertEquals(array('col 1 value', 'col 2 value', 'col 3 value'), $sheet[0]);
-    }
-
-
-    /**
-     * Test that column names prepended at first row
-     * and values have been written at second line
-     * if ExcelWriter's 4-th parameter set to true
-     *
-     * @author  Igor Mukhin <igor.mukhin@gmail.com>
-     */
-    public function testHeaderPrependedWhenOptionSetToTrue()
-    {
-        $file = tempnam(sys_get_temp_dir(), null);
-
-        $writer = new ExcelWriter(new \SplFileObject($file, 'w'), null, 'Xlsx', true);
-        $writer->prepare();
-        $writer->writeItem(array(
-            'col 1 name' => 'col 1 value',
-            'col 2 name' => 'col 2 value',
-            'col 3 name' => 'col 3 value',
-        ));
-        $writer->finish();
-
-        $excel = IOFactory::load($file);
-        $sheet = $excel->getActiveSheet()->toArray();
-
-        // Check column names at first line
-        $this->assertEquals(array('col 1 name', 'col 2 name', 'col 3 name'), $sheet[0]);
-
-        // Check values at second line
-        $this->assertEquals(array('col 1 value', 'col 2 value', 'col 3 value'), $sheet[1]);
     }
 }

--- a/tests/ExcelWriterTest.php
+++ b/tests/ExcelWriterTest.php
@@ -25,12 +25,12 @@ class ExcelWriterTest extends \PHPUnit_Framework_TestCase
 
         $writer->writeItem(array(
             'first' => 'James',
-            'last'  => 'Bond'
+            'last'  => 'Bond',
         ));
 
         $writer->writeItem(array(
             'first' => '',
-            'last'  => 'Dr. No'
+            'last'  => 'Dr. No',
         ));
 
         $writer->finish();
@@ -44,7 +44,7 @@ class ExcelWriterTest extends \PHPUnit_Framework_TestCase
 
         $writer->writeItem(array(
             'first' => 'Miss',
-            'last'  => 'Moneypenny'
+            'last'  => 'Moneypenny',
         ));
 
         $writer->finish();
@@ -85,7 +85,7 @@ class ExcelWriterTest extends \PHPUnit_Framework_TestCase
         $writer->writeItem(array(
             'col 1 name'=>'col 1 value',
             'col 2 name'=>'col 2 value',
-            'col 3 name'=>'col 3 value'
+            'col 3 name'=>'col 3 value',
         ));
         $writer->finish();
 
@@ -113,7 +113,7 @@ class ExcelWriterTest extends \PHPUnit_Framework_TestCase
         $writer->writeItem(array(
             'col 1 name'=>'col 1 value',
             'col 2 name'=>'col 2 value',
-            'col 3 name'=>'col 3 value'
+            'col 3 name'=>'col 3 value',
         ));
         $writer->finish();
 

--- a/tests/ExcelWriterTest.php
+++ b/tests/ExcelWriterTest.php
@@ -92,7 +92,7 @@ class ExcelWriterTest extends \PHPUnit_Framework_TestCase
         $excel = IOFactory::load($file);
         $sheet = $excel->getActiveSheet()->toArray();
 
-        # Values should be at first line
+        // Values should be at first line
         $this->assertEquals(array('col 1 value', 'col 2 value', 'col 3 value'), $sheet[0]);
     }
 
@@ -120,10 +120,10 @@ class ExcelWriterTest extends \PHPUnit_Framework_TestCase
         $excel = IOFactory::load($file);
         $sheet = $excel->getActiveSheet()->toArray();
 
-        # Check column names at first line
+        // Check column names at first line
         $this->assertEquals(array('col 1 name', 'col 2 name', 'col 3 name'), $sheet[0]);
 
-        # Check values at second line
+        // Check values at second line
         $this->assertEquals(array('col 1 value', 'col 2 value', 'col 3 value'), $sheet[1]);
     }
 }

--- a/tests/ExcelWriterTest.php
+++ b/tests/ExcelWriterTest.php
@@ -1,5 +1,27 @@
 <?php
+/*
+The MIT License (MIT)
 
+Copyright (c) 2015 PortPHP
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
 namespace Port\Excel\Tests;
 
 use Port\Excel\ExcelWriter;

--- a/tests/ExcelWriterTest.php
+++ b/tests/ExcelWriterTest.php
@@ -3,6 +3,7 @@
 namespace Port\Excel\Tests;
 
 use Port\Excel\ExcelWriter;
+use PhpOffice\PhpSpreadsheet\IOFactory;
 
 class ExcelWriterTest extends \PHPUnit_Framework_TestCase
 {
@@ -48,7 +49,7 @@ class ExcelWriterTest extends \PHPUnit_Framework_TestCase
 
         $writer->finish();
 
-        $excel = \PHPExcel_IOFactory::load($file);
+        $excel = IOFactory::load($file);
 
         $this->assertTrue($excel->sheetNameExists('Sheet 1'));
         $this->assertEquals(3, $excel->getSheetByName('Sheet 1')->getHighestRow());
@@ -79,7 +80,7 @@ class ExcelWriterTest extends \PHPUnit_Framework_TestCase
     {
         $file = tempnam(sys_get_temp_dir(), null);
 
-        $writer = new ExcelWriter(new \SplFileObject($file, 'w'), null, 'Excel2007');
+        $writer = new ExcelWriter(new \SplFileObject($file, 'w'), null, 'Xlsx');
         $writer->prepare();
         $writer->writeItem(array(
             'col 1 name'=>'col 1 value',
@@ -88,7 +89,7 @@ class ExcelWriterTest extends \PHPUnit_Framework_TestCase
         ));
         $writer->finish();
 
-        $excel = \PHPExcel_IOFactory::load($file);
+        $excel = IOFactory::load($file);
         $sheet = $excel->getActiveSheet()->toArray();
 
         # Values should be at first line
@@ -107,7 +108,7 @@ class ExcelWriterTest extends \PHPUnit_Framework_TestCase
     {
         $file = tempnam(sys_get_temp_dir(), null);
 
-        $writer = new ExcelWriter(new \SplFileObject($file, 'w'), null, 'Excel2007', true);
+        $writer = new ExcelWriter(new \SplFileObject($file, 'w'), null, 'Xlsx', true);
         $writer->prepare();
         $writer->writeItem(array(
             'col 1 name'=>'col 1 value',
@@ -116,7 +117,7 @@ class ExcelWriterTest extends \PHPUnit_Framework_TestCase
         ));
         $writer->finish();
 
-        $excel = \PHPExcel_IOFactory::load($file);
+        $excel = IOFactory::load($file);
         $sheet = $excel->getActiveSheet()->toArray();
 
         # Check column names at first line


### PR DESCRIPTION
There's quite of bit of stuff in here. If you don't want it all I can cherry-pick for you.

### Summary of Changes
- Convert all usages of PHPExcel to PHPSpreadsheet
- PortPHP/Excel should really just be for proper spreadsheet files. CSV is served much better by PortPHP/Csv 
- 100% code coverage in unit tests.
- Added PHP Code Sniffer and Symfony 2 rules.
- Added PHP Static Analysis Tool 
- Added Makefile for easy testing